### PR TITLE
Update MD024 to accept multiple headings

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -115,9 +115,9 @@
   // MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
   "MD024": {
     // Only check sibling headings
-    "allow_different_nesting": false,
+    "allow_different_nesting": true,
     // Only check sibling headings
-    "siblings_only": false
+    "siblings_only": true
   },
 
   // MD025/single-title/single-h1 - Multiple top-level headings in the same document


### PR DESCRIPTION
Suggested standardize markdown update to .markdownlint.jsonc file by editing `MD024 `.
Updating the Boolean value of `allow_different_nesting` and `siblings_only` into `true`

After changing this value, `npm run lint:md` will accept the duplicate-header with multiple headings with the same content.

Accepted style:
```
# Change Logs

## Release 1.0.0
### Features

## Realease 1.0.1
### Features
```
